### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the homepage for **Tuffix**, the educational programming environment use
 
 To install Tuffix, please [follow the installation instructions](https://github.com/CSUF-Tuffix/Tuffix-2/wiki/Installation-Instructions) in the wiki.
 
-If you are having trouble using the `tuffix` command or Tuffix environment, please ask for help in the Tuffix Slack channel. The [instructions say how to connect to the Slack channel][https://github.com/CSUF-Tuffix/Tuffix-2/wiki/Installation-Instructions#where-to-get-help).
+If you are having trouble using the `tuffix` command or Tuffix environment, please ask for help in the Tuffix Slack channel. These [instructions say how to connect to the Slack channel](https://github.com/CSUF-Tuffix/Tuffix-2/wiki/Installation-Instructions#where-to-get-help).
 
 If you are certain that you have found a bug in the `tuffix` command or error in the instructions, please file an Issue using the Issues tab above.
 


### PR DESCRIPTION
Minor fix on a hyperlink for the Slack workspace instructions